### PR TITLE
Improve smart config generation

### DIFF
--- a/baqend/_ConfigBuilder.ts
+++ b/baqend/_ConfigBuilder.ts
@@ -1,5 +1,7 @@
 import { Condition, Config, Rule } from './_Config'
 
+export const CONFIG_MAX_SIZE: number = 50
+
 export class ConfigBuilder {
 
   private appName: string
@@ -10,13 +12,13 @@ export class ConfigBuilder {
   /**
    * The current size of the config counting all included conditions.
    */
-  private size: number = 0
-  private maxCapacity: number
+  private _size: number = 0
+  private _maxCapacity: number
 
-  constructor(appName: string, userAgentDetection: boolean, maxCapacity: number = -1) {
+  constructor(appName: string, userAgentDetection: boolean, maxCapacity: number = CONFIG_MAX_SIZE) {
     this.appName = appName
     this.userAgentDetection = userAgentDetection
-    this.maxCapacity = maxCapacity
+    this._maxCapacity = maxCapacity
   }
 
   build(): Config {
@@ -36,16 +38,16 @@ export class ConfigBuilder {
   /**
    * Returns the size of the config counting all included conditions.
    */
-  getSize(): number {
-    return this.size
+  get size(): number {
+    return this._size
   }
 
-  capacityReached(): boolean {
-    if (this.maxCapacity === -1) {
+  get isCapacityReached(): boolean {
+    if (this._maxCapacity === -1) {
       return false
     }
 
-    return this.getSize() >= this.maxCapacity;
+    return this.size >= this._maxCapacity;
   }
 
   whitelistHost(host: Condition): this {
@@ -65,10 +67,10 @@ export class ConfigBuilder {
   }
 
   private addToWhitelist(section: 'host' | 'pathname' | 'url', value: Condition): this {
-    if (this.capacityReached()) {
+    if (this.isCapacityReached) {
       return this
     }
-    this.size++
+    this._size = this._size + 1
 
     for (const rule of this.whitelist) {
       const condition: Condition | undefined = rule[section]
@@ -98,10 +100,10 @@ export class ConfigBuilder {
   }
 
   private addToBlacklist(section: 'host' | 'pathname' | 'url', value: Condition): this {
-    if (this.capacityReached()) {
+    if (this.isCapacityReached) {
       return this
     }
-    this.size++
+    this._size = this._size + 1
 
     for (const rule of this.blacklist) {
       const condition: Condition | undefined = rule[section]

--- a/baqend/_ConfigBuilder.ts
+++ b/baqend/_ConfigBuilder.ts
@@ -7,9 +7,16 @@ export class ConfigBuilder {
   private whitelist: Rule[] = []
   private blacklist: Rule[] = []
 
-  constructor(appName: string, userAgentDetection: boolean) {
+  /**
+   * The current size of the config counting all included conditions.
+   */
+  private size: number = 0
+  private maxCapacity: number
+
+  constructor(appName: string, userAgentDetection: boolean, maxCapacity: number = -1) {
     this.appName = appName
     this.userAgentDetection = userAgentDetection
+    this.maxCapacity = maxCapacity
   }
 
   build(): Config {
@@ -24,6 +31,21 @@ export class ConfigBuilder {
     }
 
     return config
+  }
+
+  /**
+   * Returns the size of the config counting all included conditions.
+   */
+  getSize(): number {
+    return this.size
+  }
+
+  capacityReached(): boolean {
+    if (this.maxCapacity === -1) {
+      return false
+    }
+
+    return this.getSize() >= this.maxCapacity;
   }
 
   whitelistHost(host: Condition): this {
@@ -43,6 +65,11 @@ export class ConfigBuilder {
   }
 
   private addToWhitelist(section: 'host' | 'pathname' | 'url', value: Condition): this {
+    if (this.capacityReached()) {
+      return this
+    }
+    this.size++
+
     for (const rule of this.whitelist) {
       const condition: Condition | undefined = rule[section]
       // Add to existing entry
@@ -71,6 +98,11 @@ export class ConfigBuilder {
   }
 
   private addToBlacklist(section: 'host' | 'pathname' | 'url', value: Condition): this {
+    if (this.capacityReached()) {
+      return this
+    }
+    this.size++
+
     for (const rule of this.blacklist) {
       const condition: Condition | undefined = rule[section]
       // Add to existing entry

--- a/baqend/_ConfigBuilder.ts
+++ b/baqend/_ConfigBuilder.ts
@@ -43,10 +43,6 @@ export class ConfigBuilder {
   }
 
   get isCapacityReached(): boolean {
-    if (this._maxCapacity === -1) {
-      return false
-    }
-
     return this.size >= this._maxCapacity;
   }
 
@@ -70,7 +66,7 @@ export class ConfigBuilder {
     if (this.isCapacityReached) {
       return this
     }
-    this._size = this._size + 1
+    this._size += 1
 
     for (const rule of this.whitelist) {
       const condition: Condition | undefined = rule[section]
@@ -103,7 +99,7 @@ export class ConfigBuilder {
     if (this.isCapacityReached) {
       return this
     }
-    this._size = this._size + 1
+    this._size += 1
 
     for (const rule of this.blacklist) {
       const condition: Condition | undefined = rule[section]

--- a/baqend/_ConfigGenerator.ts
+++ b/baqend/_ConfigGenerator.ts
@@ -194,7 +194,7 @@ export class ConfigGenerator {
    */
   private matchOtherTopLevelDomains(domain: string): RegExp {
     if (/([\w-]+\.)[\w-]+$/.test(domain)) {
-      return  new RegExp(`${escapeRegExp(RegExp.$1)}[\\w-]+$`)
+      return new RegExp(`${escapeRegExp(RegExp.$1)}[\\w-]+$`)
     }
 
     return dollarRegExp(toRegExp(domain))

--- a/baqend/_ConfigGenerator.ts
+++ b/baqend/_ConfigGenerator.ts
@@ -9,7 +9,6 @@ import { PuppeteerResource } from './_Puppeteer'
 import credentials from './credentials'
 
 export const CDN_LOCAL_URL = 'https://makefast.app.baqend.com/v1/file/www/selfMaintainedCDNList'
-const CONFIG_MAX_SIZE = 50;
 
 type Conditions = (string | RegExp)[]
 
@@ -59,7 +58,7 @@ export class ConfigGenerator {
    * @return {Promise<Config>} A smart config for Speed Kit.
    */
   async generateSmart(url: string, mobile: boolean, thirdParty: boolean, { host, domains, resources }: { host: string, domains: string[], resources: PuppeteerResource[] }): Promise<Config> {
-    const configBuilder = new ConfigBuilder(credentials.app, mobile, CONFIG_MAX_SIZE)
+    const configBuilder = new ConfigBuilder(credentials.app, mobile)
 
     // Add host to whitelist
     const hostMatcher = this.matchAllSubdomains(host)
@@ -194,14 +193,17 @@ export class ConfigGenerator {
    * @return {RegExp} The regex that matches all subdomains of the given domain as well as other top level domains.
    */
   private matchOtherTopLevelDomains(domain: string): RegExp {
-    return /([\w-]+\.)[\w-]+$/.test(domain) ? new RegExp(`${escapeRegExp(RegExp.$1)}[\\w-]+$`)
-      : dollarRegExp(toRegExp(domain))
+    if (/([\w-]+\.)[\w-]+$/.test(domain)) {
+      return  new RegExp(`${escapeRegExp(RegExp.$1)}[\\w-]+$`)
+    }
+
+    return dollarRegExp(toRegExp(domain))
   }
 
   /**
    * Determines whether a resource is a jQuery callback.
    */
   private isJQueryCallback(resource: PuppeteerResource): boolean {
-    return !!resource.url.match(/[\?,\&]callback=/)
+    return !!resource.url.match(/[\?\&]callback=/)
   }
 }

--- a/public/selfMaintainedCDNList
+++ b/public/selfMaintainedCDNList
@@ -40,9 +40,14 @@ code.jquery.com
 fast.fonts
 bildstatic.de
 cdn
-asset.
-assets.
-static.
+asset
+assets
+static
 ajax.googleapis.com
 use.fontawesome.com
 storage.googleapis.com
+js.
+css.
+images
+s.hdnux.com
+hearst.blueconic.net


### PR DESCRIPTION
* Add cdn domains
* Only add domains and urls to whitelist if they are not covered by host regex
* Add domains where only the top level domains differs from the tested host
* Blacklist all urls that have `callback=` in their query parameters
* Restrict size of config to prevent errors on webpagetest API